### PR TITLE
docs: Signaling Proposal: Upgrade the chain for introducing a min-commission-rate parameter and setting it to 3%

### DIFF
--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -1,0 +1,43 @@
+# Signaling Proposal: Upgrade the chain for introducing a min-commission-rate parameter and setting it to 3%
+
+
+## Proposal
+
+Previously, the proposal #6 "Increase minimum commission rate to 5%" was submitted but was rejected: https://www.mintscan.io/medibloc/proposals/6.
+This topic has been discussed for a very long time in the Cosmos ecosystem: https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505.
+
+Although the proposal #6 was reasonable enough, MediBloc team also rejected the proposal #6 because we didn't have clear strategies and implementations for enforcing validators to increase their commission rate.
+
+Also, the team thought that the ideal network should work without minimum commission rate. So, instead of having the restriction, we have convinces some validators to set the reasonable commission rate. Thankfully, many validators have increased their commission rate. But, that is the inefficient and not-decentralized way. Instead, we have found that it is beneficial to have minimum commission rate at least while the chain is in early stage. This will improve network sustainability and make it possible for validators to compete in healthy ways without setting commission rate to 0%.
+
+Since then, MediBloc team has implemented a `min-commission-rate` parameter and a chain upgrade strategy for updating the commission rate of validators whose commission rate is smaller than `min-commission-rate`.
+
+Now, MediBloc team is proposing to upgrade the chain to have the `min-commission-rate` parameter and set it to 3% in order to improve network sustainability.
+
+
+## What the chain upgrade contains
+
+- The `medibloc/cosmos-sdk v0.42.11-panacea` is used instead of the `comsos/cosmos-sdk v0.42.9`.
+    - The `medibloc/cosmos-sdk` is a simple fork of `cosmos/cosmos-sdk` with the new `min-commission-rate` parameter in the `x/staking` module.
+    - https://github.com/medibloc/cosmos-sdk/pull/27 (already the same as the fork that Osmosis team had implemented)
+- The value of `min-commission-rate` is set to 3%.
+- The comission rate of validator whose current commission rate is smaller than `min-commission-rate` is changed to 3% automatically.
+    - If their commssion max rate is also smaller than `min-commssion-rate`, it is changed to 6% (= 2 * 3%) automatically.
+    - https://github.com/medibloc/panacea-core/pull/291
+
+
+## How the chain upgrade will be performed
+
+If this singaling proposal is approved, MediBloc team will submit a SoftwareUpgrade proposal for upgrading the chain from v2.0.2 to v2.0.3 which contains all changes mentioned above.
+
+If the SoftwareUpgrade proposal is approved, the chain upgrade should be performed at the promised time by all validators and full node operators. All upgrade processes related to `min-commission-rate` are performed by the chain upgrade handler automatcally.
+
+
+## What's next?
+
+MediBloc team is working on designing/implementing the Data Market Protocol on Panacea, so that individual data owners can provide/sell their data to individuals/companies who are willing to pay cryptocurrency for it.
+That would be the core value of patient-centric healthcare data ecosystem that MediBloc wants to contribute to build.
+
+It would be great if we can make the network more sustainable and healthier before releasing the data market protocol on Panacea, so that the protocol can be run securly.
+
+The revised Panacea roadmap can be found at https://medibloc.gitbook.io/panacea-core/overview/roadmap.

--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -3,19 +3,19 @@
 
 ## Proposal
 
-Previously, the proposal #6 "Increase minimum commission rate to 5%" was submitted but was rejected.<br>
-https://www.mintscan.io/medibloc/proposals/6
-
-This topic has been discussed for a very long time in the Cosmos ecosystem.<br>
+The topic of min-commision-rate has been discussed for a very long time in the Cosmos ecosystem.<br>
 https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505
 
-Although proposal #6 was reasonable enough, MediBloc team also rejected it because we didn't have clear strategies and implementations for enforcing validators to increase their commission rate.
+Even in Panacea, the proposal to increase minimum commision rate to 5% (proposal #6) was submitted previously.<br>
+https://www.mintscan.io/medibloc/proposals/6
 
-Also, the team thought that the ideal network should work without a minimum commission rate. So, instead of having the restriction, we have convinced some validators to set a reasonable commission rate. Thankfully, many validators have increased their commission rate. But, that is the inefficient and not-decentralized way. Instead, we have found that it is beneficial to have a minimum commission rate at least while the chain is in early-stage. This will improve network sustainability and make it possible for validators to compete in healthy ways without setting the commission rate to 0%.
+Although proposal #6 was reasonable enough, MediBloc team rejected the proposoal because the team has yet to develop clear strategies to enforce the validators with low commision rate to increase their commission rate.
+
+Also, the team thought that the ideal network should work without a restriction on commission rate. So, instead of implementing the restriction, the team has convinced those validators with 0% commision rate to raise its commission rate to a reasonable rate. Thankfully, many validators have cooperated with us and raised their commision rates. But, after doing so, we realized that our approach is the inefficient and non-decentralized way. Hence, we have found it beneficial to have a minimum commission rate at least while the chain is in the early-stage. We belive this will improve the network sustainability and make it possible for validators to compete in healthy ways without setting the commission rate to 0%.
 
 Since then, MediBloc team has implemented a `min-commission-rate` parameter and a chain upgrade strategy for updating the commission rate of validators whose commission rate is smaller than `min-commission-rate`.
 
-Now, MediBloc team is proposing to upgrade the chain to have the `min-commission-rate` parameter and set it to 3% to improve network sustainability.
+Now, MediBloc team is proposing to upgrade the chain to contain the `min-commission-rate` parameter and set it to 3% to improve network sustainability.
 
 
 ## What the chain upgrade contains
@@ -32,16 +32,16 @@ Now, MediBloc team is proposing to upgrade the chain to have the `min-commission
 
 ## How the chain upgrade will be performed
 
-If this signaling proposal is approved, MediBloc team will submit a SoftwareUpgrade proposal for upgrading the chain from v2.0.2 to v2.0.3 which contains all changes mentioned above.
+If this signaling proposal is approved, MediBloc team will submit a SoftwareUpgrade proposal for upgrading the chain from v2.0.2 to v2.0.3 which contains all the changes mentioned above.
 
-If the SoftwareUpgrade proposal is approved, the chain upgrade should be performed at the promised time by all validators and full node operators. All upgrade processes related to `min-commission-rate` are performed by the chain upgrade handler automatically.
+If and when the SoftwareUpgrade proposal is approved, the chain upgrade should be performed at the promised time by all validators and full node operators. All upgrade processes related to `min-commission-rate` will be performed by the chain upgrade handler automatically.
 
 
 ## What's next
 
 MediBloc team is working on designing/implementing the Data Market Protocol on Panacea, so that individual data owners can provide/sell their data to individuals/companies who are willing to pay cryptocurrency for it.
-That would be the core value of the patient-centric healthcare data ecosystem that MediBloc wants to contribute to building.
+This protocol will be a crucial piece to the patient-centric healthcare data ecosystem that MediBloc ultimately wants to build for the society.
 
-It would be great if we can make the network more sustainable and healthier before releasing the data market protocol on Panacea, so that the protocol can be run securely.
+It would be great if we can make the network more sustainable and healthier before releasing the data market protocol on Panacea, so that the protocol runs securely on Panacea.
 
 The revised Panacea roadmap can be found at https://medibloc.gitbook.io/panacea-core/overview/roadmap.

--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -24,6 +24,7 @@ Now, MediBloc team is proposing to upgrade the chain to have the `min-commission
     - The `medibloc/cosmos-sdk` is a simple fork of `cosmos/cosmos-sdk` with the new `min-commission-rate` parameter in the `x/staking` module.
     - https://github.com/medibloc/cosmos-sdk/pull/27 (almost the same as the fork that Osmosis team had implemented)
 - The value of `min-commission-rate` is set to 3%.
+    - Nobody can execute `create-validator` and `edit-validator` transactions with a commission rate smaller than `min-commission-rate`.
 - The commission rate of validators whose current commission rate is smaller than `min-commission-rate` is changed to 3% automatically.
     - If their commission max rate is also smaller than `min-commission-rate`, it is changed to 6% (= 2 * 3%) automatically.
     - https://github.com/medibloc/panacea-core/pull/291

--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -4,10 +4,10 @@
 ## Proposal
 
 Previously, the proposal #6 "Increase minimum commission rate to 5%" was submitted but was rejected.<br>
-https://www.mintscan.io/medibloc/proposals/6.
+https://www.mintscan.io/medibloc/proposals/6
 
 This topic has been discussed for a very long time in the Cosmos ecosystem.<br>
-https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505.
+https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505
 
 Although the proposal #6 was reasonable enough, MediBloc team also rejected it because we didn't have clear strategies and implementations for enforcing validators to increase their commission rate.
 

--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -3,10 +3,13 @@
 
 ## Proposal
 
-Previously, the proposal #6 "Increase minimum commission rate to 5%" was submitted but was rejected: https://www.mintscan.io/medibloc/proposals/6.
-This topic has been discussed for a very long time in the Cosmos ecosystem: https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505.
+Previously, the proposal #6 "Increase minimum commission rate to 5%" was submitted but was rejected.<br>
+https://www.mintscan.io/medibloc/proposals/6.
 
-Although the proposal #6 was reasonable enough, MediBloc team also rejected the proposal #6 because we didn't have clear strategies and implementations for enforcing validators to increase their commission rate.
+This topic has been discussed for a very long time in the Cosmos ecosystem.<br>
+https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505.
+
+Although the proposal #6 was reasonable enough, MediBloc team also rejected it because we didn't have clear strategies and implementations for enforcing validators to increase their commission rate.
 
 Also, the team thought that the ideal network should work without minimum commission rate. So, instead of having the restriction, we have convinces some validators to set the reasonable commission rate. Thankfully, many validators have increased their commission rate. But, that is the inefficient and not-decentralized way. Instead, we have found that it is beneficial to have minimum commission rate at least while the chain is in early stage. This will improve network sustainability and make it possible for validators to compete in healthy ways without setting commission rate to 0%.
 
@@ -19,7 +22,7 @@ Now, MediBloc team is proposing to upgrade the chain to have the `min-commission
 
 - The `medibloc/cosmos-sdk v0.42.11-panacea` is used instead of the `comsos/cosmos-sdk v0.42.9`.
     - The `medibloc/cosmos-sdk` is a simple fork of `cosmos/cosmos-sdk` with the new `min-commission-rate` parameter in the `x/staking` module.
-    - https://github.com/medibloc/cosmos-sdk/pull/27 (already the same as the fork that Osmosis team had implemented)
+    - https://github.com/medibloc/cosmos-sdk/pull/27 (almost the same as the fork that Osmosis team had implemented)
 - The value of `min-commission-rate` is set to 3%.
 - The comission rate of validator whose current commission rate is smaller than `min-commission-rate` is changed to 3% automatically.
     - If their commssion max rate is also smaller than `min-commssion-rate`, it is changed to 6% (= 2 * 3%) automatically.

--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -9,13 +9,13 @@ https://www.mintscan.io/medibloc/proposals/6
 This topic has been discussed for a very long time in the Cosmos ecosystem.<br>
 https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505
 
-Although the proposal #6 was reasonable enough, MediBloc team also rejected it because we didn't have clear strategies and implementations for enforcing validators to increase their commission rate.
+Although proposal #6 was reasonable enough, MediBloc team also rejected it because we didn't have clear strategies and implementations for enforcing validators to increase their commission rate.
 
-Also, the team thought that the ideal network should work without minimum commission rate. So, instead of having the restriction, we have convinces some validators to set the reasonable commission rate. Thankfully, many validators have increased their commission rate. But, that is the inefficient and not-decentralized way. Instead, we have found that it is beneficial to have minimum commission rate at least while the chain is in early stage. This will improve network sustainability and make it possible for validators to compete in healthy ways without setting commission rate to 0%.
+Also, the team thought that the ideal network should work without a minimum commission rate. So, instead of having the restriction, we have convinced some validators to set a reasonable commission rate. Thankfully, many validators have increased their commission rate. But, that is the inefficient and not-decentralized way. Instead, we have found that it is beneficial to have a minimum commission rate at least while the chain is in early-stage. This will improve network sustainability and make it possible for validators to compete in healthy ways without setting the commission rate to 0%.
 
 Since then, MediBloc team has implemented a `min-commission-rate` parameter and a chain upgrade strategy for updating the commission rate of validators whose commission rate is smaller than `min-commission-rate`.
 
-Now, MediBloc team is proposing to upgrade the chain to have the `min-commission-rate` parameter and set it to 3% in order to improve network sustainability.
+Now, MediBloc team is proposing to upgrade the chain to have the `min-commission-rate` parameter and set it to 3% to improve network sustainability.
 
 
 ## What the chain upgrade contains
@@ -24,23 +24,23 @@ Now, MediBloc team is proposing to upgrade the chain to have the `min-commission
     - The `medibloc/cosmos-sdk` is a simple fork of `cosmos/cosmos-sdk` with the new `min-commission-rate` parameter in the `x/staking` module.
     - https://github.com/medibloc/cosmos-sdk/pull/27 (almost the same as the fork that Osmosis team had implemented)
 - The value of `min-commission-rate` is set to 3%.
-- The comission rate of validator whose current commission rate is smaller than `min-commission-rate` is changed to 3% automatically.
-    - If their commssion max rate is also smaller than `min-commssion-rate`, it is changed to 6% (= 2 * 3%) automatically.
+- The commission rate of validators whose current commission rate is smaller than `min-commission-rate` is changed to 3% automatically.
+    - If their commission max rate is also smaller than `min-commission-rate`, it is changed to 6% (= 2 * 3%) automatically.
     - https://github.com/medibloc/panacea-core/pull/291
 
 
 ## How the chain upgrade will be performed
 
-If this singaling proposal is approved, MediBloc team will submit a SoftwareUpgrade proposal for upgrading the chain from v2.0.2 to v2.0.3 which contains all changes mentioned above.
+If this signaling proposal is approved, MediBloc team will submit a SoftwareUpgrade proposal for upgrading the chain from v2.0.2 to v2.0.3 which contains all changes mentioned above.
 
-If the SoftwareUpgrade proposal is approved, the chain upgrade should be performed at the promised time by all validators and full node operators. All upgrade processes related to `min-commission-rate` are performed by the chain upgrade handler automatcally.
+If the SoftwareUpgrade proposal is approved, the chain upgrade should be performed at the promised time by all validators and full node operators. All upgrade processes related to `min-commission-rate` are performed by the chain upgrade handler automatically.
 
 
 ## What's next?
 
 MediBloc team is working on designing/implementing the Data Market Protocol on Panacea, so that individual data owners can provide/sell their data to individuals/companies who are willing to pay cryptocurrency for it.
-That would be the core value of patient-centric healthcare data ecosystem that MediBloc wants to contribute to build.
+That would be the core value of the patient-centric healthcare data ecosystem that MediBloc wants to contribute to building.
 
-It would be great if we can make the network more sustainable and healthier before releasing the data market protocol on Panacea, so that the protocol can be run securly.
+It would be great if we can make the network more sustainable and healthier before releasing the data market protocol on Panacea, so that the protocol can be run securely.
 
 The revised Panacea roadmap can be found at https://medibloc.gitbook.io/panacea-core/overview/roadmap.

--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -37,7 +37,7 @@ If this signaling proposal is approved, MediBloc team will submit a SoftwareUpgr
 If the SoftwareUpgrade proposal is approved, the chain upgrade should be performed at the promised time by all validators and full node operators. All upgrade processes related to `min-commission-rate` are performed by the chain upgrade handler automatically.
 
 
-## What's next?
+## What's next
 
 MediBloc team is working on designing/implementing the Data Market Protocol on Panacea, so that individual data owners can provide/sell their data to individuals/companies who are willing to pay cryptocurrency for it.
 That would be the core value of the patient-centric healthcare data ecosystem that MediBloc wants to contribute to building.

--- a/proposals/2022-04-min-commission-rate/README.md
+++ b/proposals/2022-04-min-commission-rate/README.md
@@ -3,15 +3,15 @@
 
 ## Proposal
 
-The topic of min-commision-rate has been discussed for a very long time in the Cosmos ecosystem.<br>
+The topic of min-commission-rate has been discussed for a very long time in the Cosmos ecosystem.<br>
 https://forum.cosmos.network/t/proposal-are-validators-charging-0-commission-harmful-to-the-success-of-the-cosmos-hub/2505
 
-Even in Panacea, the proposal to increase minimum commision rate to 5% (proposal #6) was submitted previously.<br>
+Even in Panacea, the proposal to increase minimum commission rate to 5% (proposal #6) was submitted previously.<br>
 https://www.mintscan.io/medibloc/proposals/6
 
-Although proposal #6 was reasonable enough, MediBloc team rejected the proposoal because the team has yet to develop clear strategies to enforce the validators with low commision rate to increase their commission rate.
+Although proposal #6 was reasonable enough, MediBloc team rejected the proposal because the team has yet to develop clear strategies to enforce the validators with low commission rate to increase their commission rate.
 
-Also, the team thought that the ideal network should work without a restriction on commission rate. So, instead of implementing the restriction, the team has convinced those validators with 0% commision rate to raise its commission rate to a reasonable rate. Thankfully, many validators have cooperated with us and raised their commision rates. But, after doing so, we realized that our approach is the inefficient and non-decentralized way. Hence, we have found it beneficial to have a minimum commission rate at least while the chain is in the early-stage. We belive this will improve the network sustainability and make it possible for validators to compete in healthy ways without setting the commission rate to 0%.
+Also, the team thought that the ideal network should work without a restriction on commission rate. So, instead of implementing the restriction, the team has convinced those validators with 0% commission rate to raise its commission rate to a reasonable rate. Thankfully, many validators have cooperated with us and raised their commission rates. But, after doing so, we realized that our approach is the inefficient and non-decentralized way. Hence, we have found it beneficial to have a minimum commission rate at least while the chain is in the early-stage. We believe this will improve the network sustainability and make it possible for validators to compete in healthy ways without setting the commission rate to 0%.
 
 Since then, MediBloc team has implemented a `min-commission-rate` parameter and a chain upgrade strategy for updating the commission rate of validators whose commission rate is smaller than `min-commission-rate`.
 

--- a/proposals/2022-04-min-commission-rate/proposal.json
+++ b/proposals/2022-04-min-commission-rate/proposal.json
@@ -1,0 +1,3 @@
+{
+    "TODO": "Fill this JSON!"
+}


### PR DESCRIPTION
This is a signaling proposal for informing validators/delegators before posting the real SoftwareUpgrade proposal.