### PR TITLE
docs: add a SoftwareUpgrade proposal for v2.0.3

### DIFF
--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -5,7 +5,7 @@
 
 This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
-The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/2.
+The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/7.
 For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.
 
 

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -1,0 +1,25 @@
+# Upgrade the chain to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%
+
+
+### Proposal
+
+This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%.
+
+A signaling proposal for this had been already approved: https://www.mintscan.io/medibloc/proposals/2.
+For more details about the motivation of introducing the min-commission-rate parameter, please see the signaling proposal.
+
+
+### What the chain upgrade contains
+
+Please see a release note: https://github.com/medibloc/panacea-core/releases/tag/v2.0.3
+
+
+### Required actions by node operators
+
+If this SoftwareUpgrade proposal is approved, the state machine of the `panacead` will be stopped as soon as a proposed block time '2022-05-11 07:00:00 UTC' is reached.
+It means that new blocks will not be produced until the `panacead` daemon is restarted with the new version.
+
+Then, please replace the old `panacead` binary with the new one and restart the daemon by the following guide.
+https://github.com/medibloc/panacea-mainnet/blob/master/panacea-3/v2.0.3/upgrade.md
+
+If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed as well.

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -9,7 +9,7 @@ The signaling proposal for this change has already been approved: https://www.mi
 For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.
 
 
-### What the chain upgrade contains
+### What this chain upgrade contains
 
 Please see a release note: https://github.com/medibloc/panacea-core/releases/tag/v2.0.3
 

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -11,7 +11,7 @@ For more details about the rationale behind our introducing the min-commission-r
 
 ### What this chain upgrade contains
 
-Please see a release note: https://github.com/medibloc/panacea-core/releases/tag/v2.0.3
+Please see the release note: https://github.com/medibloc/panacea-core/releases/tag/v2.0.3
 
 
 ### Required actions by node operators

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -3,7 +3,7 @@
 
 ### Proposal
 
-This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
+This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and set it to 3%.
 
 The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/7.
 For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -19,7 +19,7 @@ Please see the release note: https://github.com/medibloc/panacea-core/releases/t
 If this SoftwareUpgrade proposal is approved, the state machine of the `panacead` will be stopped as soon as a proposed block time '2022-05-11 07:00:00 UTC' is reached.
 It means that new blocks will not be produced until the `panacead` daemon is restarted with the new version.
 
-Then, please replace the old `panacead` binary with the new one and restart the daemon by the following guide.
+Hence, please replace the old `panacead` binary with the new one and restart the daemon by following the guide below.
 https://github.com/medibloc/panacea-mainnet/blob/master/panacea-3/v2.0.3/upgrade.md
 
 If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed as well.

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -22,4 +22,4 @@ It means that new blocks will not be produced until the `panacead` daemon is res
 Hence, please replace the old `panacead` binary with the new one and restart the daemon by following the guide below.
 https://github.com/medibloc/panacea-mainnet/blob/master/panacea-3/v2.0.3/upgrade.md
 
-If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed as well.
+If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed manually before starting the auto-download.

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -3,7 +3,7 @@
 
 ### Proposal
 
-This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%.
+This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
 A signaling proposal for this had been already approved: https://www.mintscan.io/medibloc/proposals/2.
 For more details about the motivation of introducing the min-commission-rate parameter, please see the signaling proposal.

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -5,7 +5,7 @@
 
 This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
-A signaling proposal for this had been already approved: https://www.mintscan.io/medibloc/proposals/2.
+The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/2.
 For more details about the motivation of introducing the min-commission-rate parameter, please see the signaling proposal.
 
 

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/README.md
@@ -6,7 +6,7 @@
 This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
 The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/2.
-For more details about the motivation of introducing the min-commission-rate parameter, please see the signaling proposal.
+For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.
 
 
 ### What the chain upgrade contains

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+panacead tx gov submit-proposal software-upgrade v2.0.3 \
+	--upgrade-time "2022-05-11T07:00:00Z" \
+	--node https://rpc.gopanacea.org:443 \
+	--chain-id panacea-3 \
+	--from panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3 \
+	--fees 1000000umed \
+	--gas auto \
+	-b block \
+	--deposit "10000000000umed" \
+	--title "Upgrade the chain to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%" \
+	--description "### Proposal
+	
+This proposal is for upgrading the Panacea mainnet 'panacea-3' from v2.0.2 to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%.
+
+A signaling proposal for this had been already approved: https://www.mintscan.io/medibloc/proposals/2.
+For more details about the motivation of introducing the min-commission-rate parameter, please see the signaling proposal.
+
+
+### What the chain upgrade contains
+
+Please see a release note: https://github.com/medibloc/panacea-core/releases/tag/v2.0.3
+
+
+### Required actions by node operators
+
+If this SoftwareUpgrade proposal is approved, the state machine of the 'panacead' will be stopped as soon as a proposed block time '2022-05-11 07:00:00 UTC' is reached.
+It means that new blocks will not be produced until the 'panacead' daemon is restarted with the new version.
+
+Then, please replace the old 'panacead' binary with the new one and restart the daemon by the following guide.
+https://github.com/medibloc/panacea-mainnet/blob/master/panacea-3/v2.0.3/upgrade.md
+
+If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed as well."
+

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -14,7 +14,7 @@ panacead tx gov submit-proposal software-upgrade v2.0.3 \
 	--title "Upgrade the chain to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%" \
 	--description "### Proposal
 	
-This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
+This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and set it to 3%.
 
 The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/7.
 For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -16,7 +16,7 @@ panacead tx gov submit-proposal software-upgrade v2.0.3 \
 	
 This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
-A signaling proposal for this had been already approved: https://www.mintscan.io/medibloc/proposals/2.
+The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/2.
 For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.
 
 

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -30,7 +30,7 @@ Please see a release note: https://github.com/medibloc/panacea-core/releases/tag
 If this SoftwareUpgrade proposal is approved, the state machine of the 'panacead' will be stopped as soon as a proposed block time '2022-05-11 07:00:00 UTC' is reached.
 It means that new blocks will not be produced until the 'panacead' daemon is restarted with the new version.
 
-Then, please replace the old 'panacead' binary with the new one and restart the daemon by the following guide.
+Hence, please replace the old 'panacead' binary with the new one and restart the daemon by following the guide below.
 https://github.com/medibloc/panacea-mainnet/blob/master/panacea-3/v2.0.3/upgrade.md
 
 If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed as well."

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -14,7 +14,7 @@ panacead tx gov submit-proposal software-upgrade v2.0.3 \
 	--title "Upgrade the chain to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%" \
 	--description "### Proposal
 	
-This proposal is for upgrading the Panacea mainnet 'panacea-3' from v2.0.2 to v2.0.3 for introducing a min-commission-rate parameter and setting it to 3%.
+This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
 A signaling proposal for this had been already approved: https://www.mintscan.io/medibloc/proposals/2.
 For more details about the motivation of introducing the min-commission-rate parameter, please see the signaling proposal.

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -16,7 +16,7 @@ panacead tx gov submit-proposal software-upgrade v2.0.3 \
 	
 This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
-The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/2.
+The signaling proposal for this change has already been approved: https://www.mintscan.io/medibloc/proposals/7.
 For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.
 
 

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -33,5 +33,5 @@ It means that new blocks will not be produced until the 'panacead' daemon is res
 Hence, please replace the old 'panacead' binary with the new one and restart the daemon by following the guide below.
 https://github.com/medibloc/panacea-mainnet/blob/master/panacea-3/v2.0.3/upgrade.md
 
-If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed as well."
+If you are using the 'cosmovisor', please build the new 'panacead' binary manually and put that under the 'upgrade' directory. The auto-download is not supported yet because the appropriate version of the 'libwasmvm.so' must be installed manually before starting the auto-download."
 

--- a/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
+++ b/proposals/2022-04-upgrade-v2-0-3-min-commission-rate/submit.sh
@@ -17,7 +17,7 @@ panacead tx gov submit-proposal software-upgrade v2.0.3 \
 This proposal is for upgrading the Panacea mainnet `panacea-3` from v2.0.2 to v2.0.3 to introduce a min-commission-rate parameter and setting it to 3%.
 
 A signaling proposal for this had been already approved: https://www.mintscan.io/medibloc/proposals/2.
-For more details about the motivation of introducing the min-commission-rate parameter, please see the signaling proposal.
+For more details about the rationale behind our introducing the min-commission-rate parameter, please see the signaling proposal.
 
 
 ### What the chain upgrade contains


### PR DESCRIPTION
Tested on the testnet: https://testnet-explorer.gopanacea.org/proposals/8. The testnet was upgrade to v2.0.3 successfully.

I set the update time to 2022-05-11 07:00:00 UTC.
- for all validators in Europe and Asia
- to provide ample advance notice to central exchanges